### PR TITLE
Fix severity type int to Severity

### DIFF
--- a/buildlog/models.go
+++ b/buildlog/models.go
@@ -13,23 +13,23 @@ type Severity int
 
 const (
 	// SeverityDefault provides severity level.
-	SeverityDefault Severity = 0
+	SeverityDefault Severity = iota * 100
 	// SeverityDebug provides severity level.
-	SeverityDebug = 100
+	SeverityDebug
 	// SeverityInfo provides severity level.
-	SeverityInfo = 200
+	SeverityInfo
 	// SeverityNotice provides severity level.
-	SeverityNotice = 300
+	SeverityNotice
 	// SeverityWarning provides severity level.
-	SeverityWarning = 400
+	SeverityWarning
 	// SeverityError provides severity level.
-	SeverityError = 500
+	SeverityError
 	// SeverityCritical provides severity level.
-	SeverityCritical = 600
+	SeverityCritical
 	// SeverityAlert provides severity level.
-	SeverityAlert = 700
+	SeverityAlert
 	// SeverityEmergency provides severity level.
-	SeverityEmergency = 800
+	SeverityEmergency
 )
 
 // MarshalJSON convert raw value to JSON value.


### PR DESCRIPTION
Severity constant type is int, except for SeverityDefault.

```go
type Severity int

const (
	SeverityDefault Severity = 0
	SeverityDebug            = 100
	SeverityInfo             = 200
)

func main() {
	fmt.Printf("SeverityDefault=%v, type: %v\n", SeverityDefault, reflect.TypeOf(SeverityDefault))
	fmt.Printf("SeverityDebug=%v, type: %v\n", SeverityDebug, reflect.TypeOf(SeverityDebug))
	fmt.Printf("SeverityInfo=%v, type: %v\n", SeverityInfo, reflect.TypeOf(SeverityInfo))
}
```

```
SeverityDefault=0, type: main.Severity
SeverityDebug=100, type: int
SeverityInfo=200, type: int
```

sample code
https://play.golang.org/p/af-ovnV0a-6